### PR TITLE
Allow for static_info_tables 6.x

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,7 +16,7 @@ $EM_CONF['static_info_tables_ko'] = [
         'depends' => [
             'typo3' => '8.7.0-10.2.99',
             'php' => '7.0.0-7.4.99',
-            'static_info_tables' => '6.7.0-6.7.99',
+            'static_info_tables' => '6.7.0-6.9.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Raising the restriction allows for installation with static_info_tables 6.8, which provides PHP 7.4.

See here: https://github.com/manuelselbach/static_info_tables/commits/6.8.0