### PR TITLE
[BUGFIX] fix typoscript-condition for TYPO3 >= V9.5

### DIFF
--- a/Configuration/PageTSconfig/Suggest_prior_9.tsconfig
+++ b/Configuration/PageTSconfig/Suggest_prior_9.tsconfig
@@ -1,9 +1,0 @@
-# ***************************************************************************************
-# Translate currency labels in suggestions
-# ***************************************************************************************
-[language = *ko*]
-    TCEFORM.sys_language.static_lang_isocode.suggest.default.additionalSearchFields = lg_name_ko
-    TCEFORM.sys_language.static_lang_isocode.suggest.default.orderBy = lg_name_ko
-    TCEFORM.static_countries.cn_currency_uid.suggest.default.additionalSearchFields = cu_name_ko
-    TCEFORM.static_countries.cn_currency_uid.suggest.default.orderBy = cu_name_ko
-[global]

--- a/Configuration/PageTSconfig/Suggest_prior_9.tsconfig
+++ b/Configuration/PageTSconfig/Suggest_prior_9.tsconfig
@@ -1,7 +1,7 @@
 # ***************************************************************************************
 # Translate currency labels in suggestions
 # ***************************************************************************************
-[siteLanguage("twoLetterIsoCode") == "ko"]
+[language = *ko*]
     TCEFORM.sys_language.static_lang_isocode.suggest.default.additionalSearchFields = lg_name_ko
     TCEFORM.sys_language.static_lang_isocode.suggest.default.orderBy = lg_name_ko
     TCEFORM.static_countries.cn_currency_uid.suggest.default.additionalSearchFields = cu_name_ko

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -5,6 +5,5 @@ call_user_func(
     function($extensionKey) {
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extensionKey . '/Configuration/TypoScript/Extbase/setup.typoscript">');
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extensionKey . '/Configuration/PageTSconfig/Suggest.tsconfig">');
-
     }, \Bitmotion\StaticInfoTablesKo\Extension::EXTENSION_KEY
 );

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,6 +4,16 @@ defined('TYPO3_MODE') || die;
 call_user_func(
     function($extensionKey) {
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extensionKey . '/Configuration/TypoScript/Extbase/setup.typoscript">');
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extensionKey . '/Configuration/PageTSconfig/Suggest.tsconfig">');
+
+        if (version_compare(TYPO3_branch, '9.5', '>=')) {
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
+                '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extensionKey . '/Configuration/PageTSconfig/Suggest.tsconfig">'
+            );
+        } else {
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
+                '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extensionKey . '/Configuration/PageTSconfig/Suggest_prior_9.tsconfig">'
+            );
+        }
+
     }, \Bitmotion\StaticInfoTablesKo\Extension::EXTENSION_KEY
 );

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,16 +4,7 @@ defined('TYPO3_MODE') || die;
 call_user_func(
     function($extensionKey) {
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extensionKey . '/Configuration/TypoScript/Extbase/setup.typoscript">');
-
-        if (version_compare(TYPO3_branch, '9.5', '>=')) {
-            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-                '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extensionKey . '/Configuration/PageTSconfig/Suggest.tsconfig">'
-            );
-        } else {
-            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-                '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extensionKey . '/Configuration/PageTSconfig/Suggest_prior_9.tsconfig">'
-            );
-        }
+        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $extensionKey . '/Configuration/PageTSconfig/Suggest.tsconfig">');
 
     }, \Bitmotion\StaticInfoTablesKo\Extension::EXTENSION_KEY
 );


### PR DESCRIPTION
An outdated typoscript-condition is throwing an error in the log for TYPO3 >= 9.5
`component="TYPO3.CMS.Frontend.Configuration.TypoScript.ConditionMatching.ConditionMatcher": Expression could not be parsed. - {"expression":"language = *ko*"}`
Similar to other static_info_tables-extensions, I've added two versions, one for V9 and up, one for V8 and below